### PR TITLE
Implement exposing custom metrics arriving at publisher

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -9,6 +9,11 @@
 			"Rev": "55eb11d21d2a31a3cc93838241d04800f52e823d"
 		},
 		{
+			"ImportPath": "github.com/google/cadvisor/info/v1",
+			"Comment": "v0.23.2-6-g1c8d789",
+			"Rev": "1c8d7896a5225400df51b47330b50368e548eb94"
+		},
+		{
 			"ImportPath": "github.com/gorilla/context",
 			"Rev": "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
 		},

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -22,6 +22,7 @@ package exchange
 import (
 	"sync"
 	"time"
+	cadv "github.com/google/cadvisor/info/v1"
 )
 
 type StatsRequest struct {
@@ -49,6 +50,7 @@ type StatsRequest struct {
 
 type InnerState struct {
 	sync.RWMutex
-	DockerPaths   map[string]string
-	DockerStorage map[string]interface{}
+	DockerPaths    map[string]string
+	DockerStorage  map[string]interface{}
+	PendingMetrics map[string]map[string][]cadv.MetricVal
 }

--- a/metric_tmpl.json
+++ b/metric_tmpl.json
@@ -33,7 +33,9 @@
 		"has_network":true,
 		"has_filesystem":true,
 		"has_diskio":false,
-		"has_custom_metrics":false,
+		"has_custom_metrics":true,
+		"custom_metrics": [
+		],
 		"image":"__tmpl|/image_name|docker|str"
 	},
 	"stats":[
@@ -135,7 +137,10 @@
 					"io_time":0,
 					"weighted_io_time":0
 				}
-			]
+			],
+			"custom_metrics": {
+
+			}
 		}
 	]
 }

--- a/publisher/metric_tmpl.go
+++ b/publisher/metric_tmpl.go
@@ -54,7 +54,9 @@ const builtinMetricTemplate = `{
 		"has_network":true,
 		"has_filesystem":true,
 		"has_diskio":false,
-		"has_custom_metrics":false,
+		"has_custom_metrics":true,
+		"custom_metrics":[
+		],
 		"image":"__tmpl|/image_name|docker|str"
 	},
 	"stats":[
@@ -156,8 +158,9 @@ const builtinMetricTemplate = `{
 					"io_time":0,
 					"weighted_io_time":0
 				}
-			]
+			],
+			"custom_metrics":{
+			}
 		}
 	]
-}
-`
+}`


### PR DESCRIPTION
- custom metrics are recognized by presence of any of tags (custom_metric_name, ~_type, ~_format, ~_units)
- metric tags are exposed as values in custom_metric spec
- only one of tags is needed to enable custom metrics (others receive defaults which are: stringified namespace, "gauge" type, IntValue format, "none" units)
- debug output (.stderr) for custom metrics may be disabled with env var DISABLE_PRI
- note: added dependency on cadvisor
- note: POC quality
